### PR TITLE
Document M0 execution plan and templates

### DIFF
--- a/spec/m0_bridge_spike.md
+++ b/spec/m0_bridge_spike.md
@@ -1,0 +1,31 @@
+# M0 Swift↔︎C++ Bridge Spike Log
+
+> **Goal:** Prove that a Swift target can call into a compiled Orca Slicer C++ symbol on iOS simulator (and device if available), documenting every step for future automation.
+
+## 1. Spike Metadata
+- **Owner(s):** _(name)_
+- **Date(s) Run:** _(YYYY-MM-DD)_
+- **Toolchain:** _(Xcode version, command-line tools, additional SDKs)_
+- **Source Locations:** _(links to sandbox project, scripts, or branches)_
+
+## 2. Build Steps
+1. _(Document command or Xcode action)_
+2. _(Document command or Xcode action)_
+3. _(Document verification step)_
+
+## 3. Verification Results
+- ✅ Simulator run log: _(attach console output)_
+- ✅ SwiftUI (or UIKit) UI confirmation: _(screenshot/log reference)_
+- ⚠️ Device run (if applicable): _(status / blockers)_
+
+## 4. Issues & Follow-ups
+| Issue ID | Description | Severity | Owner | Mitigation / Next Step | Linked Ticket |
+|----------|-------------|----------|-------|------------------------|--------------|
+| B-001 | _(example: linker error for libstdc++)_ | High | _(name)_ | _(action)_ | _(link)_ |
+
+## 5. Learnings & Recommendations
+- _(Summarize what worked well and what to avoid.)_
+- _(Identify dependencies that require updates before M2.)_
+- _(List doc updates needed for Developer Experience.)_
+
+> **Reminder:** Update the Orchestrator and Core Packaging Agent once the spike results are logged to unblock M1 planning.

--- a/spec/m0_dependency_inventory.md
+++ b/spec/m0_dependency_inventory.md
@@ -1,0 +1,14 @@
+# M0 Dependency Inventory
+
+> **Instructions:** Catalog every library, module, and external asset required to build the Orca Slicer core for iOS. Update the status column as progress is made. Use “Green” when confirmed iOS-ready, “Yellow” when investigation is ongoing, and “Red” when a blocker exists. Link detailed notes or tickets where applicable.
+
+| Component | Location / Target | Type (Static/Shared/Header-only) | License | iOS Compatibility Notes | Current Status (G/Y/R) | Owner | Planned Mitigation | Target Milestone |
+|-----------|-------------------|----------------------------------|---------|------------------------|------------------------|-------|--------------------|------------------|
+| _Example: libcurl_ | `deps/libcurl` | Shared | MIT | Requires Secure Transport build; investigate `ENABLE_IPV6` flags | Yellow | Core Packaging | Evaluate using Apple CFNetwork API or build with custom toolchain | M2 |
+
+- **Last Updated:** _(fill in)_
+- **Reference Commands:**
+  - `rg "find_package" -g"CMakeLists.txt"`
+  - `cmake --graphviz=deps.dot` (visualize target relationships)
+
+> **Reminder:** Record any licensing red flags separately for Quality Agent review.

--- a/spec/m0_packaging_findings.md
+++ b/spec/m0_packaging_findings.md
@@ -1,0 +1,27 @@
+# M0 Packaging Experiments Log
+
+> **Purpose:** Capture every packaging experiment run during M0 so the team can make a data-backed recommendation for how to ship the Orca Slicer core to iOS.
+
+## 1. Experiment Summary Table
+| Experiment ID | Date | Owner | Option Tested | Command(s) / Script | Outcome | Key Logs / Links | Follow-up |
+|---------------|------|-------|---------------|---------------------|---------|------------------|-----------|
+| P-001 | _(fill in)_ | _(name)_ | Static `.a` via CMake toolchain | `./scripts/???` | _(Success/Issue)_ | _(link to log)_ | _(next steps)_ |
+
+## 2. Detailed Notes Template
+```
+### Experiment {ID}
+- Environment:
+  - macOS version:
+  - Xcode / clang version:
+  - Additional toolchains:
+- Commands executed:
+- Artifact produced (path, size):
+- Issues observed:
+- Mitigations attempted:
+- Recommendation / impact on decision:
+```
+
+## 3. Open Questions
+- _(capture decisions or data gaps that need to be resolved before M0 closure)_
+
+> **Reminder:** Attach relevant log files or CI job links where possible so future phases can reproduce the results.

--- a/spec/m0_project_setup.md
+++ b/spec/m0_project_setup.md
@@ -1,0 +1,129 @@
+# M0 – Project Setup & Discovery Execution Guide
+
+## 1. Goal & Exit Criteria
+- **Objective:** Validate that the existing Orca Slicer codebase and toolchain can be positioned for iOS builds without blocking downstream milestones.
+- **Exit Criteria:**
+  - Dependency inventory complete with iOS compatibility assessment and mitigation owners logged.
+  - Packaging recommendation (static `.a` vs `.xcframework`) documented with supporting evidence and decision recorded in `spec/phase1_decisions.md`.
+  - Swift↔︎C++ bridge spike demonstrating invocation of a C++ symbol from Swift on an Apple toolchain, with findings summarized and blockers captured.
+  - Reporting artifacts updated: Kanban tickets, daily async posts, and checklist sign-off submitted to the Orchestrator.
+
+## 2. Timeline (Week 0 Breakdown)
+| Day | Focus | Primary Owner(s) | Expected Output |
+| --- | --- | --- | --- |
+| Day 1 | Kickoff, inventory scope alignment, toolchain environment check | Orchestrator + Core Packaging + Developer Experience | Meeting notes, updated Kanban cards |
+| Day 2 | Dependency inventory deep dive | Core Packaging | Initial pass of inventory template with priority components |
+| Day 3 | Packaging option experiments & criteria scoring | Core Packaging + Bridge & Data | Pros/cons matrix draft, build logs |
+| Day 4 | Swift↔︎C++ spike implementation & validation | Bridge & Data + Swift App Shell | Minimal project compiling/running, spike notes |
+| Day 5 | Consolidate findings, document risks, prepare M1 handoff inputs | Orchestrator + all agents | Finalized artifacts committed, decision log entry, M1 readiness review |
+
+*Adjust sequencing as needed for regional holidays; any slip beyond Day 5 requires an Orchestrator-approved change request.*
+
+## 3. Work Package Details
+
+### 3.1 Dependency Inventory & Risk Scan
+- **Owner:** Core Packaging Agent (support from Quality & Developer Experience).
+- **Steps:**
+  1. Parse `CMakeLists.txt`, `deps/`, and `deps_src/` to enumerate build targets and third-party libraries.
+  2. Populate `spec/m0_dependency_inventory.md` (template below) capturing component details, license, platform assumptions, and iOS readiness status.
+  3. Flag blockers with proposed mitigation (stub, replace, conditional compile) and assign a target resolution milestone.
+  4. Share early findings with Bridge & Data Agent to anticipate bridging constraints.
+- **Tools & References:**
+  - `cmake --graphviz` or `cmake --trace-expand` to surface dependency graphs.
+  - `rg "add_subdirectory"` / `rg "find_package"` for quick enumeration.
+  - License references stored under `LICENSE.txt` and `deps_src` metadata.
+- **Deliverables:** Inventory document, risk list annotated with severity, and a summary comment in the async status thread.
+
+### 3.2 Packaging Strategy Decision
+- **Owner:** Core Packaging Agent (Bridge & Data + Developer Experience consult, Quality approval).
+- **Evaluation Criteria:**
+  - Simulator & device compatibility (`arm64-apple-ios-simulator`, `arm64-apple-ios`).
+  - Integration friction for Swift (XCFramework adoption vs. manual linking in Xcode project or Swift Package Manager).
+  - Build reproducibility within CI (scriptability, deterministic artifacts).
+  - Binary size & symbol visibility impacts.
+  - Licensing considerations when distributing binaries.
+- **Tasks:**
+  1. Produce a pros/cons matrix covering at least static `.a`, `.xcframework`, and (if feasible) Swift Package Manager binary target.
+  2. Run exploratory builds using the existing toolchain; capture commands, environment, and observed issues in `spec/m0_packaging_findings.md`.
+  3. Summarize recommendation, include data (build duration, artifact size), and log the final decision in `spec/phase1_decisions.md` with Quality Agent sign-off.
+  4. Notify Swift App Shell Agent of expected integration touchpoints (header search paths, module maps).
+- **Deliverables:** Pros/cons matrix, build experiment notes, decision log entry, updated risk register if blockers persist.
+
+### 3.3 Swift↔︎C++ Bridge Spike
+- **Owner:** Bridge & Data Agent (Swift App Shell support, Quality review).
+- **Spike Scope:**
+  - Create a minimal C++ function (e.g., `const char* orca_version();`) compiled into a static library for iOS simulator.
+  - Expose the symbol through an Objective-C++ wrapper (`extern "C"` function) and import it in a Swift target via bridging header.
+  - Run on both simulator (required) and physical device if available (stretch goal) to validate code signing/toolchain steps.
+- **Steps:**
+  1. Stand up a temporary Xcode project (`sandbox/ios_spike/`) or Swift Package referencing the compiled library.
+  2. Document compiler flags, header search paths, and any linker tweaks needed for libc++ / libstdc++ compatibility.
+  3. Verify runtime call by logging to console and, if possible, surfacing a simple SwiftUI label.
+  4. Record findings—including pain points, tooling versions, and open questions—in `spec/m0_bridge_spike.md`.
+  5. Hand results to Core Packaging Agent to validate assumptions for M2.
+- **Exit Criteria:** Spike project builds without manual Xcode UI tweaks (scriptable), bridging header pattern agreed upon, and risk notes filed if unresolved.
+
+### 3.4 Developer Experience & Quality Hooks
+- **Owner:** Developer Experience Agent (Quality consult, Orchestrator oversight).
+- **Actions:**
+  - Initialize `spec/phase1_decisions.md` using the template provided in this repo.
+  - Draft README addendum summarizing M0 prerequisites (toolchains, dependencies, macOS version) and link to above spike documents.
+  - Ensure each artifact includes metadata: owner, date, contact channel, follow-up tasks.
+  - Quality Agent to craft a review checklist focusing on C++/Swift integration hygiene, licensing verification, and documentation completeness.
+- **Deliverables:** Updated documentation, checklist appended to the `spec/m0_project_setup.md` appendix, and validation that async reporting cadence is established.
+
+## 4. Roles & RACI Matrix
+| Task | Core Packaging | Bridge & Data | Swift App Shell | Developer Experience | Quality | Orchestrator |
+| --- | --- | --- | --- | --- | --- | --- |
+| Dependency inventory | **R/A** | C | C | C | C | I |
+| Packaging decision | **R/A** | R | C | C | A | I |
+| Bridge spike | C | **R/A** | R | I | C | I |
+| Documentation updates | C | I | I | **R/A** | C | I |
+| Risk tracking & reporting | C | C | C | C | C | **R/A** |
+
+*R = Responsible, A = Accountable, C = Consulted, I = Informed.*
+
+## 5. Exit Checklist (Complete All Before Closing M0)
+- [ ] `spec/m0_dependency_inventory.md` filled with status “Green/Yellow/Red” for each component.
+- [ ] Packaging recommendation documented with acceptance from Quality Agent.
+- [ ] Bridge spike log captures build commands, tool versions, and outcomes for simulator (and device if possible).
+- [ ] README addendum + decision log entries merged to `main`.
+- [ ] Risks escalated with mitigation owners and due dates.
+- [ ] Orchestrator sign-off recorded in weekly sync notes.
+
+## 6. Reporting Expectations
+- Twice-weekly async updates (Tue/Fri) summarizing progress, blockers, and next steps.
+- Sync meeting minutes stored under `spec/` with filenames `m0_sync_YYYYMMDD.md`.
+- Orchestrator reviews artifacts daily and ensures blockers are recorded within 24h.
+
+## 7. Appendices
+### 7.1 Dependency Inventory Template Reference
+```
+| Component | Location | Type (Static/Shared/Header-only) | License | iOS Compatibility Notes | Current Status (G/Y/R) | Owner | Planned Mitigation | Target Milestone |
+|-----------|----------|----------------------------------|---------|------------------------|------------------------|-------|--------------------|------------------|
+```
+
+### 7.2 Pros/Cons Matrix Template
+```
+| Option | Pros | Cons | Notes | Recommendation |
+|--------|------|------|-------|----------------|
+```
+
+### 7.3 Spike Log Template
+```
+# Swift↔︎C++ Spike Log
+- Date:
+- Owner(s):
+- Toolchain (Xcode/clang versions):
+- Commands Executed:
+- Outcome:
+- Issues & Mitigations:
+- Follow-up Tasks:
+```
+
+### 7.4 Quality Review Checklist Seeds
+- Verify licenses for third-party dependencies permit static linking on iOS.
+- Confirm build scripts avoid hard-coded absolute paths.
+- Ensure bridge wrapper handles ownership (no raw pointers crossing boundary without contract).
+- Validate documentation includes prerequisites, steps, and expected outputs.
+- Capture unresolved blockers with severity and owner.

--- a/spec/phase1_decisions.md
+++ b/spec/phase1_decisions.md
@@ -1,0 +1,12 @@
+# Phase 1 Decision Log
+
+> **Purpose:** Track cross-team decisions that influence scope, architecture, or schedules. Each entry must reference the milestone it impacts and list required follow-ups.
+
+| ID | Date | Decision | Context / Options Considered | Owner(s) | Impacted Milestones | Follow-up Actions | Status |
+|----|------|----------|-------------------------------|----------|---------------------|-------------------|--------|
+| DEC-0001 | _(YYYY-MM-DD)_ | _(Decision summary)_ | _(Problem framing & evaluated options)_ | _(Names)_ | _(e.g., M0, M1)_ | _(Tasks, due dates)_ | _(Open/Closed)_ |
+
+> **Instructions:**
+> - Keep entries concise but link to supporting documents (e.g., `spec/m0_packaging_findings.md`).
+> - Update status when actions complete; closed decisions should note validation evidence.
+> - Orchestrator reviews log weekly and ensures impacted agents acknowledge updates.

--- a/spec/phase1_orchestration.md
+++ b/spec/phase1_orchestration.md
@@ -1,0 +1,72 @@
+# Phase 1 Orchestration Plan
+
+## 1. Mission Control Overview
+- **Scope:** Coordinate agents to deliver the Phase 1 objectives defined in `ios_phase1_plan.md`.
+- **Reporting cadence:** Weekly orchestration sync each Monday (UTC) with shared minutes; mid-week async checkpoint posted in the project channel.
+- **Definition of Done (Phase 1):** Milestones M0–M7 complete with deliverables archived in `spec/` or corresponding source directories, automated checks green, and hand-off notes published.
+
+## 2. Milestone Timeline & Ownership
+| Week | Milestone(s) | Primary Lead | Key Dependencies | Exit Criteria |
+| --- | --- | --- | --- | --- |
+| Week 0 | M0 – Project Setup & Discovery | Core Packaging Agent | Access to current build scripts, dependency manifests | Dependency inventory produced; packaging decision recorded; Swift↔︎C++ spike summary committed |
+| Week 1 | M1 – Buildable iOS Shell | Swift App Shell Agent | M0 spike output (bridge feasibility); UX outline from Quality Agent | `ios/OrcaSlicerApp` skeleton builds on simulator; navigation placeholders implemented |
+| Week 2 | M2 – Orca Core Packaging | Core Packaging Agent | M0 inventory; Swift App shell target structure | Reproducible build script emits iOS-ready binary + headers; usage README drafted |
+| Week 3 | M3 – Swift/C++ Bridge | Bridge & Data Agent | Packaged library from M2; Swift shell hooks | Bridge module exposes `startSlicerEngine()`; smoke test logs result inside app |
+| Week 4 | M4 – 3D Viewer Foundations | SceneKit Viewer Agent | Swift shell baseline; asset pipeline decisions | SceneKit scene renders placeholder cube; STL load pipeline documented |
+| Week 5 | M5 – Model Manipulation | SceneKit Viewer Agent | M4 rendering; UX validation by Quality Agent | Gesture controls for rotate/translate; "On Face" alignment demo recorded |
+| Week 6 | M6 – UI → Slicer Invocation | Bridge & Data + Swift App Shell Agents | Stable bridge; slicing API contract; packaged presets from Core Packaging | Slice button triggers C++ engine; progress + status surfaced in UI |
+| Week 7 | M7 – Hardening & Hand-off | Developer Experience + Testing + Quality Agents | All prior milestones; test harness inputs; documentation drafts | QA checklist complete; build/test instructions published; retrospective logged |
+
+*Adjust timeline if blockers emerge; Orchestrator owns change control and communicates updates within 24h.*
+
+## 3. Dependency Board
+- **Toolchain readiness (M0 → M2):** Core Packaging Agent supplies compiler/toolchain matrix; Bridge & Data Agent validates symbol visibility before M3 start.
+- **SceneKit data contracts (M4 → M5 → M6):** SceneKit Viewer Agent documents mesh orientation semantics; Bridge & Data Agent confirms file hand-off format; Swift App Shell Agent handles file importer integration.
+- **Quality gates:** Quality Agent reviews milestone exit artifacts within two business days; Testing Agent refuses promotion without minimal acceptance tests per milestone.
+- **Documentation stream:** Developer Experience Agent maintains a living `docs/ios/` index; every milestone owner must PR documentation updates alongside feature changes.
+
+## 4. Execution Cadence & Governance
+- **Weekly sync agenda:**
+  1. Milestone burndown review (current/next week).
+  2. Cross-agent blockers and dependency status.
+  3. Risk register updates and mitigation decisions.
+  4. Scope change proposals (require Orchestrator approval + impacted agent sign-off).
+- **Async updates:** Each agent posts a twice-weekly status (Tue/Fri) covering progress, upcoming tasks, and help requests.
+- **Decision log:** Use `spec/phase1_decisions.md` (to be created by Developer Experience Agent) with entries capturing context, decision, owner, date, and follow-up actions.
+- **Escalation path:** Blockers exceeding 48h escalate to Orchestrator; unresolved risks escalate to product sponsor.
+
+## 5. Risk & Issue Tracking
+| ID | Risk | Owner | Mitigation | Trigger/Watchpoints |
+| --- | --- | --- | --- | --- |
+| R1 | Third-party libs fail to build for iOS | Core Packaging Agent | Identify optional components; prepare stub implementations by end of Week 0 | Missing symbols during toolchain spike |
+| R2 | Bridge memory ownership bugs | Bridge & Data Agent | Define explicit allocation contracts in API spec; add unit tests before integrating into app | Crash reports or leaks in smoke test |
+| R3 | SceneKit performance with large meshes | SceneKit Viewer Agent | Benchmark with >10MB STL by Week 5; propose LOD strategy if FPS <30 | FPS regression in profiling builds |
+| R4 | Documentation debt slowing onboarding | Developer Experience Agent | Enforce doc update checklist per PR; audit docs during Week 7 | Missing or outdated setup instructions |
+| R5 | Scope creep from slicer configuration requests | Orchestrator | Gate non-essential requests until post-Phase 1; document deferrals | New requirements raised in syncs |
+
+## 6. Immediate Next Actions (Week 0)
+- **Core Packaging Agent:** Complete dependency inventory template; evaluate static `.a` vs `.xcframework` trade-offs; publish bridge spike report.
+- **Swift App Shell Agent:** Draft SwiftUI module skeleton outline; prepare questions for UX alignment.
+- **Bridge & Data Agent:** Review C API surface requirements; partner on spike to confirm Swift bridging mechanics.
+- **SceneKit Viewer Agent:** Research SceneKit STL loading approaches; identify sample assets for testing.
+- **Developer Experience Agent:** Draft project README addendum covering Phase 1 scope; set up decision log file.
+- **Testing Agent:** Outline acceptance criteria for M1 and M2; propose minimal automated checks.
+- **Quality Agent:** Define code review checklist focusing on Swift/C++ integration and accessibility baseline.
+
+## 7. Reporting & Artifacts
+- **Status board:** Maintain an up-to-date Kanban (Backlog → In Progress → Review → Done) in the project tracker; Orchestrator audits weekly.
+- **Documentation anchors:**
+  - Architecture & decisions: `spec/`
+  - Build tooling: `scripts/` + `doc/build/`
+  - App layer guides: `doc/ios/`
+- **Handoff package (M7):** Consolidated README, build scripts, QA checklist, and backlog of deferred items archived under `spec/phase1_handoff/`.
+
+## 8. Change Control
+- Scope adjustments require a written proposal referencing milestone impact, resource adjustments, and risk deltas.
+- Orchestrator logs approved changes and communicates them during the next sync and in the shared notes.
+
+## 9. Success Metrics
+- Planned milestones achieved within ±1 week.
+- Zero P0 defects open at Phase 1 closure.
+- Documentation satisfaction score ≥4/5 from internal beta reviewers.
+- Time-to-setup for new contributors ≤2 hours by Week 7.


### PR DESCRIPTION
## Summary
- add an execution guide for Milestone 0 with timeline, work packages, and reporting expectations
- provide templates for dependency inventory, packaging experiments, bridge spike notes, and the Phase 1 decision log

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d0312fc504832ba32bc6e49604291f