### PR TITLE
Add detailed M1 execution plan and templates

### DIFF
--- a/spec/m0_bridge_spike.md
+++ b/spec/m0_bridge_spike.md
@@ -1,0 +1,31 @@
+# M0 Swift↔︎C++ Bridge Spike Log
+
+> **Goal:** Prove that a Swift target can call into a compiled Orca Slicer C++ symbol on iOS simulator (and device if available), documenting every step for future automation.
+
+## 1. Spike Metadata
+- **Owner(s):** _(name)_
+- **Date(s) Run:** _(YYYY-MM-DD)_
+- **Toolchain:** _(Xcode version, command-line tools, additional SDKs)_
+- **Source Locations:** _(links to sandbox project, scripts, or branches)_
+
+## 2. Build Steps
+1. _(Document command or Xcode action)_
+2. _(Document command or Xcode action)_
+3. _(Document verification step)_
+
+## 3. Verification Results
+- ✅ Simulator run log: _(attach console output)_
+- ✅ SwiftUI (or UIKit) UI confirmation: _(screenshot/log reference)_
+- ⚠️ Device run (if applicable): _(status / blockers)_
+
+## 4. Issues & Follow-ups
+| Issue ID | Description | Severity | Owner | Mitigation / Next Step | Linked Ticket |
+|----------|-------------|----------|-------|------------------------|--------------|
+| B-001 | _(example: linker error for libstdc++)_ | High | _(name)_ | _(action)_ | _(link)_ |
+
+## 5. Learnings & Recommendations
+- _(Summarize what worked well and what to avoid.)_
+- _(Identify dependencies that require updates before M2.)_
+- _(List doc updates needed for Developer Experience.)_
+
+> **Reminder:** Update the Orchestrator and Core Packaging Agent once the spike results are logged to unblock M1 planning.

--- a/spec/m0_dependency_inventory.md
+++ b/spec/m0_dependency_inventory.md
@@ -1,0 +1,14 @@
+# M0 Dependency Inventory
+
+> **Instructions:** Catalog every library, module, and external asset required to build the Orca Slicer core for iOS. Update the status column as progress is made. Use “Green” when confirmed iOS-ready, “Yellow” when investigation is ongoing, and “Red” when a blocker exists. Link detailed notes or tickets where applicable.
+
+| Component | Location / Target | Type (Static/Shared/Header-only) | License | iOS Compatibility Notes | Current Status (G/Y/R) | Owner | Planned Mitigation | Target Milestone |
+|-----------|-------------------|----------------------------------|---------|------------------------|------------------------|-------|--------------------|------------------|
+| _Example: libcurl_ | `deps/libcurl` | Shared | MIT | Requires Secure Transport build; investigate `ENABLE_IPV6` flags | Yellow | Core Packaging | Evaluate using Apple CFNetwork API or build with custom toolchain | M2 |
+
+- **Last Updated:** _(fill in)_
+- **Reference Commands:**
+  - `rg "find_package" -g"CMakeLists.txt"`
+  - `cmake --graphviz=deps.dot` (visualize target relationships)
+
+> **Reminder:** Record any licensing red flags separately for Quality Agent review.

--- a/spec/m0_packaging_findings.md
+++ b/spec/m0_packaging_findings.md
@@ -1,0 +1,27 @@
+# M0 Packaging Experiments Log
+
+> **Purpose:** Capture every packaging experiment run during M0 so the team can make a data-backed recommendation for how to ship the Orca Slicer core to iOS.
+
+## 1. Experiment Summary Table
+| Experiment ID | Date | Owner | Option Tested | Command(s) / Script | Outcome | Key Logs / Links | Follow-up |
+|---------------|------|-------|---------------|---------------------|---------|------------------|-----------|
+| P-001 | _(fill in)_ | _(name)_ | Static `.a` via CMake toolchain | `./scripts/???` | _(Success/Issue)_ | _(link to log)_ | _(next steps)_ |
+
+## 2. Detailed Notes Template
+```
+### Experiment {ID}
+- Environment:
+  - macOS version:
+  - Xcode / clang version:
+  - Additional toolchains:
+- Commands executed:
+- Artifact produced (path, size):
+- Issues observed:
+- Mitigations attempted:
+- Recommendation / impact on decision:
+```
+
+## 3. Open Questions
+- _(capture decisions or data gaps that need to be resolved before M0 closure)_
+
+> **Reminder:** Attach relevant log files or CI job links where possible so future phases can reproduce the results.

--- a/spec/m0_project_setup.md
+++ b/spec/m0_project_setup.md
@@ -1,0 +1,129 @@
+# M0 – Project Setup & Discovery Execution Guide
+
+## 1. Goal & Exit Criteria
+- **Objective:** Validate that the existing Orca Slicer codebase and toolchain can be positioned for iOS builds without blocking downstream milestones.
+- **Exit Criteria:**
+  - Dependency inventory complete with iOS compatibility assessment and mitigation owners logged.
+  - Packaging recommendation (static `.a` vs `.xcframework`) documented with supporting evidence and decision recorded in `spec/phase1_decisions.md`.
+  - Swift↔︎C++ bridge spike demonstrating invocation of a C++ symbol from Swift on an Apple toolchain, with findings summarized and blockers captured.
+  - Reporting artifacts updated: Kanban tickets, daily async posts, and checklist sign-off submitted to the Orchestrator.
+
+## 2. Timeline (Week 0 Breakdown)
+| Day | Focus | Primary Owner(s) | Expected Output |
+| --- | --- | --- | --- |
+| Day 1 | Kickoff, inventory scope alignment, toolchain environment check | Orchestrator + Core Packaging + Developer Experience | Meeting notes, updated Kanban cards |
+| Day 2 | Dependency inventory deep dive | Core Packaging | Initial pass of inventory template with priority components |
+| Day 3 | Packaging option experiments & criteria scoring | Core Packaging + Bridge & Data | Pros/cons matrix draft, build logs |
+| Day 4 | Swift↔︎C++ spike implementation & validation | Bridge & Data + Swift App Shell | Minimal project compiling/running, spike notes |
+| Day 5 | Consolidate findings, document risks, prepare M1 handoff inputs | Orchestrator + all agents | Finalized artifacts committed, decision log entry, M1 readiness review |
+
+*Adjust sequencing as needed for regional holidays; any slip beyond Day 5 requires an Orchestrator-approved change request.*
+
+## 3. Work Package Details
+
+### 3.1 Dependency Inventory & Risk Scan
+- **Owner:** Core Packaging Agent (support from Quality & Developer Experience).
+- **Steps:**
+  1. Parse `CMakeLists.txt`, `deps/`, and `deps_src/` to enumerate build targets and third-party libraries.
+  2. Populate `spec/m0_dependency_inventory.md` (template below) capturing component details, license, platform assumptions, and iOS readiness status.
+  3. Flag blockers with proposed mitigation (stub, replace, conditional compile) and assign a target resolution milestone.
+  4. Share early findings with Bridge & Data Agent to anticipate bridging constraints.
+- **Tools & References:**
+  - `cmake --graphviz` or `cmake --trace-expand` to surface dependency graphs.
+  - `rg "add_subdirectory"` / `rg "find_package"` for quick enumeration.
+  - License references stored under `LICENSE.txt` and `deps_src` metadata.
+- **Deliverables:** Inventory document, risk list annotated with severity, and a summary comment in the async status thread.
+
+### 3.2 Packaging Strategy Decision
+- **Owner:** Core Packaging Agent (Bridge & Data + Developer Experience consult, Quality approval).
+- **Evaluation Criteria:**
+  - Simulator & device compatibility (`arm64-apple-ios-simulator`, `arm64-apple-ios`).
+  - Integration friction for Swift (XCFramework adoption vs. manual linking in Xcode project or Swift Package Manager).
+  - Build reproducibility within CI (scriptability, deterministic artifacts).
+  - Binary size & symbol visibility impacts.
+  - Licensing considerations when distributing binaries.
+- **Tasks:**
+  1. Produce a pros/cons matrix covering at least static `.a`, `.xcframework`, and (if feasible) Swift Package Manager binary target.
+  2. Run exploratory builds using the existing toolchain; capture commands, environment, and observed issues in `spec/m0_packaging_findings.md`.
+  3. Summarize recommendation, include data (build duration, artifact size), and log the final decision in `spec/phase1_decisions.md` with Quality Agent sign-off.
+  4. Notify Swift App Shell Agent of expected integration touchpoints (header search paths, module maps).
+- **Deliverables:** Pros/cons matrix, build experiment notes, decision log entry, updated risk register if blockers persist.
+
+### 3.3 Swift↔︎C++ Bridge Spike
+- **Owner:** Bridge & Data Agent (Swift App Shell support, Quality review).
+- **Spike Scope:**
+  - Create a minimal C++ function (e.g., `const char* orca_version();`) compiled into a static library for iOS simulator.
+  - Expose the symbol through an Objective-C++ wrapper (`extern "C"` function) and import it in a Swift target via bridging header.
+  - Run on both simulator (required) and physical device if available (stretch goal) to validate code signing/toolchain steps.
+- **Steps:**
+  1. Stand up a temporary Xcode project (`sandbox/ios_spike/`) or Swift Package referencing the compiled library.
+  2. Document compiler flags, header search paths, and any linker tweaks needed for libc++ / libstdc++ compatibility.
+  3. Verify runtime call by logging to console and, if possible, surfacing a simple SwiftUI label.
+  4. Record findings—including pain points, tooling versions, and open questions—in `spec/m0_bridge_spike.md`.
+  5. Hand results to Core Packaging Agent to validate assumptions for M2.
+- **Exit Criteria:** Spike project builds without manual Xcode UI tweaks (scriptable), bridging header pattern agreed upon, and risk notes filed if unresolved.
+
+### 3.4 Developer Experience & Quality Hooks
+- **Owner:** Developer Experience Agent (Quality consult, Orchestrator oversight).
+- **Actions:**
+  - Initialize `spec/phase1_decisions.md` using the template provided in this repo.
+  - Draft README addendum summarizing M0 prerequisites (toolchains, dependencies, macOS version) and link to above spike documents.
+  - Ensure each artifact includes metadata: owner, date, contact channel, follow-up tasks.
+  - Quality Agent to craft a review checklist focusing on C++/Swift integration hygiene, licensing verification, and documentation completeness.
+- **Deliverables:** Updated documentation, checklist appended to the `spec/m0_project_setup.md` appendix, and validation that async reporting cadence is established.
+
+## 4. Roles & RACI Matrix
+| Task | Core Packaging | Bridge & Data | Swift App Shell | Developer Experience | Quality | Orchestrator |
+| --- | --- | --- | --- | --- | --- | --- |
+| Dependency inventory | **R/A** | C | C | C | C | I |
+| Packaging decision | **R/A** | R | C | C | A | I |
+| Bridge spike | C | **R/A** | R | I | C | I |
+| Documentation updates | C | I | I | **R/A** | C | I |
+| Risk tracking & reporting | C | C | C | C | C | **R/A** |
+
+*R = Responsible, A = Accountable, C = Consulted, I = Informed.*
+
+## 5. Exit Checklist (Complete All Before Closing M0)
+- [ ] `spec/m0_dependency_inventory.md` filled with status “Green/Yellow/Red” for each component.
+- [ ] Packaging recommendation documented with acceptance from Quality Agent.
+- [ ] Bridge spike log captures build commands, tool versions, and outcomes for simulator (and device if possible).
+- [ ] README addendum + decision log entries merged to `main`.
+- [ ] Risks escalated with mitigation owners and due dates.
+- [ ] Orchestrator sign-off recorded in weekly sync notes.
+
+## 6. Reporting Expectations
+- Twice-weekly async updates (Tue/Fri) summarizing progress, blockers, and next steps.
+- Sync meeting minutes stored under `spec/` with filenames `m0_sync_YYYYMMDD.md`.
+- Orchestrator reviews artifacts daily and ensures blockers are recorded within 24h.
+
+## 7. Appendices
+### 7.1 Dependency Inventory Template Reference
+```
+| Component | Location | Type (Static/Shared/Header-only) | License | iOS Compatibility Notes | Current Status (G/Y/R) | Owner | Planned Mitigation | Target Milestone |
+|-----------|----------|----------------------------------|---------|------------------------|------------------------|-------|--------------------|------------------|
+```
+
+### 7.2 Pros/Cons Matrix Template
+```
+| Option | Pros | Cons | Notes | Recommendation |
+|--------|------|------|-------|----------------|
+```
+
+### 7.3 Spike Log Template
+```
+# Swift↔︎C++ Spike Log
+- Date:
+- Owner(s):
+- Toolchain (Xcode/clang versions):
+- Commands Executed:
+- Outcome:
+- Issues & Mitigations:
+- Follow-up Tasks:
+```
+
+### 7.4 Quality Review Checklist Seeds
+- Verify licenses for third-party dependencies permit static linking on iOS.
+- Confirm build scripts avoid hard-coded absolute paths.
+- Ensure bridge wrapper handles ownership (no raw pointers crossing boundary without contract).
+- Validate documentation includes prerequisites, steps, and expected outputs.
+- Capture unresolved blockers with severity and owner.

--- a/spec/m1_app_structure.md
+++ b/spec/m1_app_structure.md
@@ -1,0 +1,57 @@
+# M1 Template – iOS App Structure Record
+
+Use this template to document the structure of the iOS application after the M1 scaffold is committed. Update sections as the directory layout evolves and keep owners current.
+
+## 1. Directory Overview
+| Path | Purpose | Owner | Notes / Follow-ups |
+| ---- | ------- | ----- | ------------------ |
+| `ios/` |  |  |  |
+| `ios/OrcaSlicerApp.xcodeproj` |  |  |  |
+| `ios/Sources/` |  |  |  |
+| `ios/Resources/` |  |  |  |
+| `ios/Support/` |  |  |  |
+| `ios/Tests/` |  |  |  |
+| _(add rows as needed)_ |  |  |  |
+
+## 2. Module & Target Breakdown
+| Target / Module | Type (App/Framework/Test) | Dependencies | Responsibilities | Status (Planned/In-Progress/Complete) |
+| --------------- | ------------------------- | ------------ | ---------------- | ----------------------------------- |
+| `OrcaSlicerApp` |  |  |  |  |
+| `ModelViewerKit` |  |  |  |  |
+| `SlicingSupport` |  |  |  |  |
+| `OrcaSlicerAppTests` |  |  |  |  |
+| _(add rows as needed)_ |  |  |  |  |
+
+## 3. Build Settings & Configurations
+- **Bundle Identifiers:**
+  - Debug:
+  - Release:
+- **Signing Strategy:** _(automatic/manual, development team, provisioning)_
+- **Configurations:** _(Debug, Release, custom configs)_
+- **Architectures:** _(simulator/device targets covered)_
+- **Custom Build Scripts:**
+  - Location:
+  - Purpose:
+- **Notable Flags / Definitions:**
+
+## 4. Shared Resources & Assets
+| Resource | Location | Used By | Notes (e.g., licensing, localization) |
+| -------- | -------- | ------- | ------------------------------------ |
+| App icons |  |  |  |
+| Placeholder STL assets |  |  |  |
+| Localization strings |  |  |  |
+| _(add rows as needed)_ |  |  |  |
+
+## 5. Integration Touchpoints
+- **Bridge Headers / Modules:**
+- **Swift Package Dependencies:**
+- **3rd-party Libraries:**
+- **Tooling Dependencies (e.g., SwiftLint):**
+
+## 6. Risks & Action Items
+| Risk / Gap | Owner | Severity | Mitigation / Next Step | Target Milestone |
+| ---------- | ----- | -------- | ---------------------- | ---------------- |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+_Last updated:_

--- a/spec/m1_build_validation.md
+++ b/spec/m1_build_validation.md
@@ -1,0 +1,38 @@
+# M1 Template – Build & Run Validation Log
+
+Record every notable build or run attempt during M1. Include simulator/device targets, commands, results, and evidence links to support milestone exit criteria.
+
+## 1. Summary Table
+| Date | Engineer | Command / Action | Target (Simulator/Device) | Result (Pass/Fail) | Evidence (Log/Screenshot) | Notes |
+| ---- | -------- | ---------------- | ------------------------- | ------------------ | ------------------------- | ----- |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+
+## 2. Detailed Entries
+### Entry Template
+- **Timestamp:**
+- **Environment:** _(macOS version, Xcode version)_
+- **Command(s):**
+  ```
+  xcodebuild ...
+  ```
+- **Outcome:**
+- **Issues Encountered:**
+- **Mitigation / Fix Applied:**
+- **Follow-up Tasks:**
+
+_Repeat for each significant run._
+
+## 3. Automated Checks & CI Status
+- **SwiftLint / SwiftFormat:** _(configured? results?)_
+- **Unit Tests:** _(list targets run, coverage)_
+- **UI Tests / Snapshots:**
+- **CI Pipeline Link / Status:**
+- **Blocking Failures:**
+
+## 4. Sign-off
+- **Quality Agent Review:**
+- **Orchestrator Approval:**
+- **Date Closed:**
+
+_Last updated:_

--- a/spec/m1_buildable_ios_shell.md
+++ b/spec/m1_buildable_ios_shell.md
@@ -1,0 +1,106 @@
+# M1 – Buildable iOS Shell Execution Guide
+
+## 1. Goal & Exit Criteria
+- **Objective:** Deliver a SwiftUI-based iOS shell that compiles and runs on simulator and device targets, establishing the directory structure, build scripts, and placeholder UI for later milestones.
+- **Exit Criteria:**
+  - Xcode project (or Swift Package) checked in under `ios/` with schemes for simulator and device, building without manual configuration.
+  - SwiftUI navigation scaffold present with placeholder screens for model browser, viewer, and slicing controls mapped to view models.
+  - File import stub implemented (using `FileImporter` or similar) persisting selected STL path for downstream milestones.
+  - App launch, navigation flow, and mock slice trigger verified via build validation log with screenshots or console output.
+  - Updated documentation: repo layout rationale, build/run steps for macOS contributors, and the populated templates defined in Appendix 7.
+
+## 2. Timeline (Week 1 Breakdown)
+| Day | Focus | Primary Owner(s) | Expected Output |
+| --- | --- | --- | --- |
+| Day 1 | Confirm requirements, align on architecture patterns, and fork repo structure | Orchestrator + Swift App Shell + Developer Experience | Kickoff notes, initial backlog, directory layout proposal |
+| Day 2 | Generate Xcode project / Swift package, configure targets & bundle identifiers | Swift App Shell (Quality consult) | `ios/OrcaSlicerApp.xcodeproj`, schemes created, signing strategy notes |
+| Day 3 | Implement SwiftUI navigation skeleton & state containers | Swift App Shell | Views scaffolded, view model protocols drafted, UI preview screenshots |
+| Day 4 | Add file import stub, mock slicer service, and persistence hooks | Swift App Shell + Bridge & Data | File importer working in simulator, stub service returning canned result |
+| Day 5 | Harden build scripts, document instructions, capture validation evidence | Developer Experience + Quality + Orchestrator | Build validation log completed, README updates merged, exit checklist review |
+
+*Shifts longer than one day must be escalated to the Orchestrator. Coordinate asynchronously for shared workstreams to avoid blocking.*
+
+## 3. Work Package Details
+
+### 3.1 Repository Layout & Build System
+- **Owner:** Swift App Shell Agent (Developer Experience consulted, Quality informed).
+- **Steps:**
+  1. Propose `ios/` directory layout: app target, shared resources, bridging headers, package manifests.
+  2. Capture structure within `spec/m1_app_structure.md`, including module boundaries and rationale.
+  3. Create Xcode project via `xcodebuild -project` compatible scripting or SPM package; ensure reproducible by adding generation script if using `xcodegen`.
+  4. Configure signing profiles for team-less debug builds (automatic signing or development team placeholder) and document requirements.
+  5. Verify builds on both `arm64-apple-ios` (device) and `arm64-apple-ios-simulator`; note any gating issues in the validation log.
+- **Deliverables:** Project file committed, structure template filled, build script or documented regeneration process, signing guidance.
+
+### 3.2 SwiftUI Shell & Navigation Framework
+- **Owner:** Swift App Shell Agent (Quality accountable for review).
+- **Steps:**
+  1. Define navigation flow (e.g., `AppEntryView -> ModelLibraryView -> ModelViewerView`), referencing `spec/m1_ui_screens.md`.
+  2. Implement placeholder views with state containers using MVVM or Composable Architecture (decision recorded in `spec/phase1_decisions.md`).
+  3. Include preview providers or unit snapshots for each view to accelerate QA.
+  4. Wire up toolbar buttons and gestures to stubbed actions (no real slicing yet) to validate event flow.
+  5. Ensure accessibility labels exist on primary UI elements and note coverage in the UI template.
+- **Deliverables:** SwiftUI source files, updated UI template, preview screenshots logged.
+
+### 3.3 File Import & Model Context Management
+- **Owner:** Swift App Shell Agent (Bridge & Data consulted).
+- **Steps:**
+  1. Choose file import mechanism (`FileImporter`, `UIDocumentPicker`) and record reasoning in `spec/phase1_decisions.md`.
+  2. Implement asynchronous importer capturing URL security-scoped bookmarks when required; store results in view model with placeholder metadata.
+  3. Update `spec/m1_stubbed_services.md` with contract for the mock `SlicingService` and data structures shared across milestones.
+  4. Provide sample STL asset for development (optional) and document location.
+  5. Ensure error handling paths display alerts or inline messaging and log coverage.
+- **Deliverables:** Importer code, stub service documentation, updated decision log entry, validation entry demonstrating importer workflow.
+
+### 3.4 Bridge Preparation & Dependency Contracts
+- **Owner:** Bridge & Data Agent (Swift App Shell consulted, Core Packaging informed).
+- **Steps:**
+  1. Define placeholder protocol or service interface that the future M3 bridge will conform to; document in stub services template.
+  2. Identify data contract: file path vs. data blob, config struct placeholder. Capture open questions.
+  3. Collaborate with Core Packaging Agent to ensure build settings align with expected binary formats (static library vs. XCFramework) and record compatibility notes.
+  4. Insert compile-time flags or dependency injection to swap stub with real bridge later without refactoring navigation layer.
+- **Deliverables:** Interface definitions, compatibility notes appended to `spec/m1_stubbed_services.md`, action items for M2/M3.
+
+### 3.5 Developer Experience & Quality Gates
+- **Owner:** Developer Experience Agent (Quality accountable, Orchestrator informed).
+- **Steps:**
+  1. Update README or create `doc/ios_setup.md` with prerequisites, build commands, simulator/device run steps.
+  2. Fill `spec/m1_build_validation.md` with each build/test run, capturing command, outcome, screenshots/log references.
+  3. Establish linting/formatting baseline (SwiftFormat/SwiftLint) and document configuration for later automation.
+  4. Coordinate with Quality Agent on review checklist (accessibility, localization placeholders, state management hygiene) and append to this guide if necessary.
+  5. Ensure CI feasibility noted (macOS runners, caching) with action items for M2.
+- **Deliverables:** Updated documentation, validation log, tooling plan, quality checklist updates.
+
+## 4. RACI Matrix
+| Task | Swift App Shell | Bridge & Data | Core Packaging | Developer Experience | Quality | Orchestrator |
+| --- | --- | --- | --- | --- | --- | --- |
+| Repository layout & project creation | **R/A** | I | C | C | C | I |
+| SwiftUI navigation & placeholder UI | **R** | C | I | I | **A** | I |
+| File import stub & context management | **R** | C | I | I | A | I |
+| Bridge contract definition | C | **R/A** | C | I | C | I |
+| Documentation & validation log | C | I | I | **R/A** | C | I |
+| Risk tracking & milestone reporting | C | C | C | C | C | **R/A** |
+
+*R = Responsible, A = Accountable, C = Consulted, I = Informed.*
+
+## 5. Exit Checklist (Complete Before Closing M1)
+- [ ] `ios/` project builds on simulator & device without manual project edits after checkout.
+- [ ] `spec/m1_app_structure.md` populated with final directory layout and module responsibilities.
+- [ ] `spec/m1_ui_screens.md` updated with each screen’s status, accessibility notes, and preview references.
+- [ ] `spec/m1_stubbed_services.md` documents mock slicing contract and integration points for real bridge.
+- [ ] `spec/m1_build_validation.md` records at least two successful build runs and one failure scenario with mitigation.
+- [ ] README / setup docs updated; PR reviewed by Quality and Orchestrator sign-off captured in sync notes.
+- [ ] All open risks logged with owners and mitigation milestones.
+
+## 6. Reporting Expectations
+- Async updates three times per week (Mon/Wed/Fri) summarizing progress, blockers, and next actions.
+- Weekly sync chaired by Orchestrator; minutes stored as `spec/m1_sync_YYYYMMDD.md`.
+- Immediate escalation to Orchestrator if build breaks for >4 working hours or signing issues block contributors.
+
+## 7. Appendices & Templates
+- **Template A:** `spec/m1_app_structure.md` – capture module layout, ownership, and dependency notes.
+- **Template B:** `spec/m1_ui_screens.md` – track screen implementation status, preview references, and accessibility coverage.
+- **Template C:** `spec/m1_stubbed_services.md` – document mock services, API contracts, and swap strategy for real bridge.
+- **Template D:** `spec/m1_build_validation.md` – log build/run attempts, outcomes, and evidence links.
+
+*Complete templates as part of milestone delivery; update decision log with any deviations from this guide.*

--- a/spec/m1_stubbed_services.md
+++ b/spec/m1_stubbed_services.md
@@ -1,0 +1,46 @@
+# M1 Template – Stubbed Services & Bridge Contracts
+
+Document the placeholder services introduced in M1 to simulate future integrations. Use this template to ensure the Swift ↔︎ C++ boundary is ready for replacement in later milestones.
+
+## 1. Service Inventory
+| Service Name | Purpose | Owner | Implementation Location | Downstream Replacement (Milestone) | Swap Strategy |
+| ------------ | ------- | ----- | ----------------------- | ---------------------------------- | ------------- |
+| `MockSlicingService` |  |  |  |  |  |
+| `MockModelRepository` |  |  |  |  |  |
+| `MockUserPreferences` |  |  |  |  |  |
+| _(add rows as needed)_ |  |  |  |  |  |
+
+## 2. API Surface (per Service)
+### Example: `MockSlicingService`
+- **Protocol / Interface Definition:**
+- **Swift Implementation Summary:**
+- **Inputs:** _(file URL, config struct, callbacks)_
+- **Outputs:** _(success/failure enum, progress updates)_
+- **Threading Expectations:**
+- **Error Handling Strategy:**
+- **Metrics / Logging Hooks:**
+
+_(Repeat subsection for each service.)_
+
+## 3. Data Contracts & Models
+| Model | Definition Location | Fields & Types | Ownership / Memory Notes | Ready for Bridge? (Y/N) | Follow-ups |
+| ----- | ------------------- | -------------- | ------------------------ | ----------------------- | ---------- |
+| `SliceJobRequest` |  |  |  |  |  |
+| `SliceJobResult` |  |  |  |  |  |
+| `ModelMetadata` |  |  |  |  |  |
+
+## 4. Integration Points
+- **Future Bridge Entry Points:**
+  - Name:
+  - Expected Signature:
+  - Notes:
+- **Dependencies on Core Packaging Artifacts:**
+- **Testing Hooks / Injected Dependencies:**
+
+## 5. Risks & Mitigations
+| Risk | Impact | Owner | Mitigation Plan | Target Review |
+| ---- | ------ | ----- | --------------- | ------------- |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+_Last updated:_

--- a/spec/m1_ui_screens.md
+++ b/spec/m1_ui_screens.md
@@ -1,0 +1,41 @@
+# M1 Template – SwiftUI Screen Tracker
+
+Use this tracker to monitor SwiftUI screen implementation during M1. Capture navigation wiring, state ownership, accessibility, and preview coverage for each view.
+
+## 1. Screen Inventory
+| Screen / View | Navigation Entry Point | Primary ViewModel / State | Key UI Elements | Accessibility Notes | Preview / Screenshot Reference | Status (Not Started/In Progress/Complete) |
+| ------------- | --------------------- | ------------------------- | --------------- | ------------------- | ------------------------------ | ---------------------------------------- |
+| `AppEntryView` |  |  |  |  |  |  |
+| `ModelLibraryView` |  |  |  |  |  |  |
+| `ModelViewerView` |  |  |  |  |  |  |
+| `SliceStatusSheet` |  |  |  |  |  |  |
+| `SettingsView` |  |  |  |  |  |  |
+| _(add rows as needed)_ |  |  |  |  |  |  |
+
+## 2. Navigation Flow Diagram (Textual)
+Describe the navigation transitions and data flow between screens.
+
+```
+AppEntryView -> ...
+```
+
+## 3. State & Dependency Mapping
+| View | Downstream Dependencies | Mock / Stub Used? | Swap Strategy for Future Milestones |
+| ---- | ---------------------- | ----------------- | ---------------------------------- |
+|  |  |  |  |
+|  |  |  |  |
+
+## 4. Accessibility & Localization Checklist
+- [ ] Dynamic Type tested for major text sizes (list sizes used).
+- [ ] VoiceOver labels provided for critical controls.
+- [ ] Color contrast checked for primary buttons / backgrounds.
+- [ ] Localization placeholders inserted (e.g., `NSLocalizedString`).
+- Notes:
+
+## 5. Outstanding Issues & Decisions
+| Issue / Decision | Owner | Raised On | Resolution / Next Step | Target Date |
+| ---------------- | ----- | --------- | ---------------------- | ----------- |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+_Last updated:_

--- a/spec/phase1_decisions.md
+++ b/spec/phase1_decisions.md
@@ -1,0 +1,12 @@
+# Phase 1 Decision Log
+
+> **Purpose:** Track cross-team decisions that influence scope, architecture, or schedules. Each entry must reference the milestone it impacts and list required follow-ups.
+
+| ID | Date | Decision | Context / Options Considered | Owner(s) | Impacted Milestones | Follow-up Actions | Status |
+|----|------|----------|-------------------------------|----------|---------------------|-------------------|--------|
+| DEC-0001 | _(YYYY-MM-DD)_ | _(Decision summary)_ | _(Problem framing & evaluated options)_ | _(Names)_ | _(e.g., M0, M1)_ | _(Tasks, due dates)_ | _(Open/Closed)_ |
+
+> **Instructions:**
+> - Keep entries concise but link to supporting documents (e.g., `spec/m0_packaging_findings.md`).
+> - Update status when actions complete; closed decisions should note validation evidence.
+> - Orchestrator reviews log weekly and ensures impacted agents acknowledge updates.

--- a/spec/phase1_orchestration.md
+++ b/spec/phase1_orchestration.md
@@ -1,0 +1,72 @@
+# Phase 1 Orchestration Plan
+
+## 1. Mission Control Overview
+- **Scope:** Coordinate agents to deliver the Phase 1 objectives defined in `ios_phase1_plan.md`.
+- **Reporting cadence:** Weekly orchestration sync each Monday (UTC) with shared minutes; mid-week async checkpoint posted in the project channel.
+- **Definition of Done (Phase 1):** Milestones M0–M7 complete with deliverables archived in `spec/` or corresponding source directories, automated checks green, and hand-off notes published.
+
+## 2. Milestone Timeline & Ownership
+| Week | Milestone(s) | Primary Lead | Key Dependencies | Exit Criteria |
+| --- | --- | --- | --- | --- |
+| Week 0 | M0 – Project Setup & Discovery | Core Packaging Agent | Access to current build scripts, dependency manifests | Dependency inventory produced; packaging decision recorded; Swift↔︎C++ spike summary committed |
+| Week 1 | M1 – Buildable iOS Shell | Swift App Shell Agent | M0 spike output (bridge feasibility); UX outline from Quality Agent | `ios/OrcaSlicerApp` skeleton builds on simulator; navigation placeholders implemented |
+| Week 2 | M2 – Orca Core Packaging | Core Packaging Agent | M0 inventory; Swift App shell target structure | Reproducible build script emits iOS-ready binary + headers; usage README drafted |
+| Week 3 | M3 – Swift/C++ Bridge | Bridge & Data Agent | Packaged library from M2; Swift shell hooks | Bridge module exposes `startSlicerEngine()`; smoke test logs result inside app |
+| Week 4 | M4 – 3D Viewer Foundations | SceneKit Viewer Agent | Swift shell baseline; asset pipeline decisions | SceneKit scene renders placeholder cube; STL load pipeline documented |
+| Week 5 | M5 – Model Manipulation | SceneKit Viewer Agent | M4 rendering; UX validation by Quality Agent | Gesture controls for rotate/translate; "On Face" alignment demo recorded |
+| Week 6 | M6 – UI → Slicer Invocation | Bridge & Data + Swift App Shell Agents | Stable bridge; slicing API contract; packaged presets from Core Packaging | Slice button triggers C++ engine; progress + status surfaced in UI |
+| Week 7 | M7 – Hardening & Hand-off | Developer Experience + Testing + Quality Agents | All prior milestones; test harness inputs; documentation drafts | QA checklist complete; build/test instructions published; retrospective logged |
+
+*Adjust timeline if blockers emerge; Orchestrator owns change control and communicates updates within 24h.*
+
+## 3. Dependency Board
+- **Toolchain readiness (M0 → M2):** Core Packaging Agent supplies compiler/toolchain matrix; Bridge & Data Agent validates symbol visibility before M3 start.
+- **SceneKit data contracts (M4 → M5 → M6):** SceneKit Viewer Agent documents mesh orientation semantics; Bridge & Data Agent confirms file hand-off format; Swift App Shell Agent handles file importer integration.
+- **Quality gates:** Quality Agent reviews milestone exit artifacts within two business days; Testing Agent refuses promotion without minimal acceptance tests per milestone.
+- **Documentation stream:** Developer Experience Agent maintains a living `docs/ios/` index; every milestone owner must PR documentation updates alongside feature changes.
+
+## 4. Execution Cadence & Governance
+- **Weekly sync agenda:**
+  1. Milestone burndown review (current/next week).
+  2. Cross-agent blockers and dependency status.
+  3. Risk register updates and mitigation decisions.
+  4. Scope change proposals (require Orchestrator approval + impacted agent sign-off).
+- **Async updates:** Each agent posts a twice-weekly status (Tue/Fri) covering progress, upcoming tasks, and help requests.
+- **Decision log:** Use `spec/phase1_decisions.md` (to be created by Developer Experience Agent) with entries capturing context, decision, owner, date, and follow-up actions.
+- **Escalation path:** Blockers exceeding 48h escalate to Orchestrator; unresolved risks escalate to product sponsor.
+
+## 5. Risk & Issue Tracking
+| ID | Risk | Owner | Mitigation | Trigger/Watchpoints |
+| --- | --- | --- | --- | --- |
+| R1 | Third-party libs fail to build for iOS | Core Packaging Agent | Identify optional components; prepare stub implementations by end of Week 0 | Missing symbols during toolchain spike |
+| R2 | Bridge memory ownership bugs | Bridge & Data Agent | Define explicit allocation contracts in API spec; add unit tests before integrating into app | Crash reports or leaks in smoke test |
+| R3 | SceneKit performance with large meshes | SceneKit Viewer Agent | Benchmark with >10MB STL by Week 5; propose LOD strategy if FPS <30 | FPS regression in profiling builds |
+| R4 | Documentation debt slowing onboarding | Developer Experience Agent | Enforce doc update checklist per PR; audit docs during Week 7 | Missing or outdated setup instructions |
+| R5 | Scope creep from slicer configuration requests | Orchestrator | Gate non-essential requests until post-Phase 1; document deferrals | New requirements raised in syncs |
+
+## 6. Immediate Next Actions (Week 0)
+- **Core Packaging Agent:** Complete dependency inventory template; evaluate static `.a` vs `.xcframework` trade-offs; publish bridge spike report.
+- **Swift App Shell Agent:** Draft SwiftUI module skeleton outline; prepare questions for UX alignment.
+- **Bridge & Data Agent:** Review C API surface requirements; partner on spike to confirm Swift bridging mechanics.
+- **SceneKit Viewer Agent:** Research SceneKit STL loading approaches; identify sample assets for testing.
+- **Developer Experience Agent:** Draft project README addendum covering Phase 1 scope; set up decision log file.
+- **Testing Agent:** Outline acceptance criteria for M1 and M2; propose minimal automated checks.
+- **Quality Agent:** Define code review checklist focusing on Swift/C++ integration and accessibility baseline.
+
+## 7. Reporting & Artifacts
+- **Status board:** Maintain an up-to-date Kanban (Backlog → In Progress → Review → Done) in the project tracker; Orchestrator audits weekly.
+- **Documentation anchors:**
+  - Architecture & decisions: `spec/`
+  - Build tooling: `scripts/` + `doc/build/`
+  - App layer guides: `doc/ios/`
+- **Handoff package (M7):** Consolidated README, build scripts, QA checklist, and backlog of deferred items archived under `spec/phase1_handoff/`.
+
+## 8. Change Control
+- Scope adjustments require a written proposal referencing milestone impact, resource adjustments, and risk deltas.
+- Orchestrator logs approved changes and communicates them during the next sync and in the shared notes.
+
+## 9. Success Metrics
+- Planned milestones achieved within ±1 week.
+- Zero P0 defects open at Phase 1 closure.
+- Documentation satisfaction score ≥4/5 from internal beta reviewers.
+- Time-to-setup for new contributors ≤2 hours by Week 7.


### PR DESCRIPTION
## Summary
- add an execution guide for Milestone 1 covering goals, timeline, work packages, RACI, and reporting expectations
- provide structured templates to capture iOS app structure, SwiftUI screen progress, stubbed services, and build validation logs for M1

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d0312fc504832ba32bc6e49604291f