### PR TITLE
Document M0 discovery findings for iOS port

### DIFF
--- a/spec/m0_bridge_spike.md
+++ b/spec/m0_bridge_spike.md
@@ -3,29 +3,31 @@
 > **Goal:** Prove that a Swift target can call into a compiled Orca Slicer C++ symbol on iOS simulator (and device if available), documenting every step for future automation.
 
 ## 1. Spike Metadata
-- **Owner(s):** _(name)_
-- **Date(s) Run:** _(YYYY-MM-DD)_
-- **Toolchain:** _(Xcode version, command-line tools, additional SDKs)_
-- **Source Locations:** _(links to sandbox project, scripts, or branches)_
+- **Owner(s):** Bridge & Data Agent (paired with Core Packaging Agent)
+- **Date(s) Run:** 2025-09-20 – 2025-09-21
+- **Toolchain:** Planned: Xcode 15 CLI tools, Swift 5.9, clang targeting `arm64-apple-ios` (not available in Linux container)
+- **Source Locations:** `sandboxes/ios_spike/` (to be created on macOS host); bridging header draft in `spec/` notes
 
 ## 2. Build Steps
-1. _(Document command or Xcode action)_
-2. _(Document command or Xcode action)_
-3. _(Document verification step)_
+1. Author minimal C++ library (`orca_version.cpp`) compiled with `clang -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator)` producing `libOrcaVersion.a` (simulator) and `libOrcaVersion_device.a` (device).
+2. Expose symbol through Objective-C++ shim (`extern "C" const char* orca_version();`) and include header in Swift bridging header within temporary Xcode project.
+3. Package libraries using `xcodebuild -create-xcframework` to unify simulator/device archives for import into Swift target.
+4. Implement SwiftUI view logging `Text("Orca version: \(OrcaBridge.shared.version())")` to confirm invocation.
 
 ## 3. Verification Results
-- ✅ Simulator run log: _(attach console output)_
-- ✅ SwiftUI (or UIKit) UI confirmation: _(screenshot/log reference)_
-- ⚠️ Device run (if applicable): _(status / blockers)_
+- ✅ Simulator run log: _Pending – blocked by unavailable Xcode toolchain in current environment._
+- ✅ SwiftUI (or UIKit) UI confirmation: _Pending – UI stub drafted but cannot be executed here._
+- ⚠️ Device run (if applicable): _Not attempted; requires developer certificate._
 
 ## 4. Issues & Follow-ups
 | Issue ID | Description | Severity | Owner | Mitigation / Next Step | Linked Ticket |
 |----------|-------------|----------|-------|------------------------|--------------|
-| B-001 | _(example: linker error for libstdc++)_ | High | _(name)_ | _(action)_ | _(link)_ |
+| B-001 | No iOS SDK or `xcodebuild` available in CI container | High | Bridge & Data Agent | Move spike to macOS runner (GitHub Actions or local Mac) and vendor `ios-cmake` toolchain | _(pending issue link)_ |
+| B-002 | Ownership semantics between Swift and C++ strings undecided | Medium | Bridge & Data Agent | Adopt `std::string` → `NSString` copy via `String(cString:)` and document lifetime in bridge header | Spec follow-up |
 
 ## 5. Learnings & Recommendations
-- _(Summarize what worked well and what to avoid.)_
-- _(Identify dependencies that require updates before M2.)_
-- _(List doc updates needed for Developer Experience.)_
+- Bridge entry point should limit surface to POD-friendly APIs (e.g., returning `const char*`) to avoid C++ ABI drift across compilers.
+- Coordinate with Core Packaging Agent on final library naming to ensure Swift modulemap remains stable between simulator/device builds.
+- Document bridging header pattern for Developer Experience Agent, including required `SWIFT_OBJC_BRIDGING_HEADER` build setting adjustments.
 
 > **Reminder:** Update the Orchestrator and Core Packaging Agent once the spike results are logged to unblock M1 planning.

--- a/spec/m0_dependency_inventory.md
+++ b/spec/m0_dependency_inventory.md
@@ -4,9 +4,20 @@
 
 | Component | Location / Target | Type (Static/Shared/Header-only) | License | iOS Compatibility Notes | Current Status (G/Y/R) | Owner | Planned Mitigation | Target Milestone |
 |-----------|-------------------|----------------------------------|---------|------------------------|------------------------|-------|--------------------|------------------|
-| _Example: libcurl_ | `deps/libcurl` | Shared | MIT | Requires Secure Transport build; investigate `ENABLE_IPV6` flags | Yellow | Core Packaging | Evaluate using Apple CFNetwork API or build with custom toolchain | M2 |
+| OrcaSlicer Core (`libslic3r`) | `src/libslic3r` | Static | AGPLv3 (project license) | Heavy use of filesystem, threading, and SIMD paths; needs iOS toolchain configuration and feature gating for wxWidgets hooks | Yellow | Core Packaging | Stand up dedicated iOS CMake toolchain; stub wxWidgets-dependent code paths | M2 |
+| Boost (selected modules) | `deps/Boost` | Header + Static (filesystem, program_options) | Boost Software License 1.0 | Majority header-only; must disable unsupported components (locale, python) and ensure `boost::filesystem` maps to libc++ on iOS | Yellow | Core Packaging | Prune build to header-only libs + filesystem; validate with clang `-target arm64-apple-ios` | M1 |
+| oneTBB | `deps/TBB` | Static | Apache 2.0 with LLVM exception | Upstream CMake does not ship iOS presets; requires custom toolchain and disabling deprecated GNU atomics | Red | Core Packaging | Evaluate community iOS patches; consider replacing with libdispatch-backed task scheduler | M2 |
+| OpenVDB | `deps/OpenVDB` | Static | MPL 2.0 | Depends on TBB, Blosc, OpenEXR; large footprint and limited benefit for Phase 1 FDM workflows | Red | Core Packaging | Exclude from iOS package for Phase 1; document feature loss (volumetric supports) | M2 |
+| GMP | `deps/GMP` | Static | GPLv3 | Assembly kernels for x86/ARM Linux fail under `arm64-apple-ios`; needs hand-tuned build scripts | Red | Core Packaging | Investigate prebuilt universal binaries or leverage Boost.Multiprecision fallback | M3 |
+| MPFR | `deps/MPFR` | Static | LGPLv3 | Requires GMP; build system lacks iOS target awareness; used for STEP/curve tooling | Red | Core Packaging | Defer STEP import on iOS; pursue rational approximation fallback before reenabling | M3 |
+| CGAL | `deps/CGAL` | Header-only + Static utilities | GPLv3/LGPLv3 | Template-heavy; depends on GMP/MPFR; pure header portions compile but kernel selection must avoid Qt/OpenGL hooks | Yellow | Core Packaging | Configure `CGAL_HEADER_ONLY=ON`; gate functionality needing exact arithmetic | M2 |
+| cURL | `deps/CURL` | Static | MIT | Needs Secure Transport backend instead of OpenSSL; current build scripts assume OpenSSL everywhere | Yellow | Core Packaging | Build with `-DCURL_USE_SECTRANSP=ON`; drop unused protocols | M2 |
+| OpenSSL | `deps/OpenSSL` | Static | Apache 2.0 | Requires separate builds for simulator/device; upstream provides `ios` script but not integrated | Yellow | Core Packaging | Automate via `./Configure ios64-simulator` & `ios64-cross`; evaluate replacing with platform Security APIs | M2 |
+| Eigen | `deps/` (via submodule) | Header-only | MPL 2.0 | Fully header-only; no platform-specific code | Green | Core Packaging | None | M1 |
+| zlib | `deps/ZLIB` | Static | zlib | Portable C implementation; compiles under generic clang | Green | Core Packaging | Ensure `CMAKE_OSX_SYSROOT` provided when cross-compiling | M1 |
+| wxWidgets | `deps/wxWidgets` | Static | wxWindows License | Desktop UI only; unused for core library but referenced in build; must be excluded from iOS configuration | Yellow | Core Packaging | Guard top-level CMake targets; confirm libslic3r does not link GUI artifacts | M1 |
 
-- **Last Updated:** _(fill in)_
+- **Last Updated:** 2025-09-21 (Core Packaging Agent)
 - **Reference Commands:**
   - `rg "find_package" -g"CMakeLists.txt"`
   - `cmake --graphviz=deps.dot` (visualize target relationships)

--- a/spec/m0_packaging_findings.md
+++ b/spec/m0_packaging_findings.md
@@ -5,23 +5,62 @@
 ## 1. Experiment Summary Table
 | Experiment ID | Date | Owner | Option Tested | Command(s) / Script | Outcome | Key Logs / Links | Follow-up |
 |---------------|------|-------|---------------|---------------------|---------|------------------|-----------|
-| P-001 | _(fill in)_ | _(name)_ | Static `.a` via CMake toolchain | `./scripts/???` | _(Success/Issue)_ | _(link to log)_ | _(next steps)_ |
+| P-001 | 2025-09-21 | Core Packaging Agent | Static `.a` via CMake cross-toolchain | `cmake -S deps -B build_ios_dep -DCMAKE_SYSTEM_NAME=iOS ...` | ❌ Failed – missing Apple SDK/compilers | `cmake` configure log | Provision macOS builder; retry with ios-cmake toolchain |
+| P-002 | 2025-09-21 | Core Packaging Agent | `.xcframework` wrapper built from static libs | `xcodebuild -create-xcframework -library libOrcaCore.a ...` (planned) | ⚠️ Blocked – requires macOS host artifacts | Packaging design doc draft | Capture dependency graph for libs to include |
+| P-003 | 2025-09-21 | Core Packaging Agent | SwiftPM binary target distribution | `swift package compute-checksum OrcaCore.xcframework` (planned) | ⚠️ Research only – evaluating feasibility | Notes in this doc | Align with Developer Experience on distribution |
 
 ## 2. Detailed Notes Template
 ```
-### Experiment {ID}
+### Experiment P-001 – Static `.a` via CMake cross-toolchain
 - Environment:
-  - macOS version:
-  - Xcode / clang version:
-  - Additional toolchains:
+  - Host: Debian container (no Apple SDK)
+  - Toolchain: System CMake 3.28, GNU build-essential
+  - Additional toolchains: None – attempted generic iOS configuration
 - Commands executed:
-- Artifact produced (path, size):
+  - `cmake -S OrcaSlicer/deps -B OrcaSlicer/build_ios_dep -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES=arm64`
+- Artifact produced (path, size): _None – configure stage failed_
 - Issues observed:
+  - CMake rejected `iphoneos` SDK due to absent Apple toolchain definitions.
+  - `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER` unset because clang with iOS sysroot was unavailable.【e1b58c†L1-L19】
 - Mitigations attempted:
+  - Reviewed community `ios-cmake` toolchain; concluded it must be vendored to proceed.
+  - Identified requirement to install Apple SDK headers or run on macOS CI host.
 - Recommendation / impact on decision:
+  - Proceed with macOS-based build host for packaging; Linux container cannot produce artifacts without significant bootstrapping.
+
+### Experiment P-002 – `.xcframework` assembly plan
+- Environment:
+  - Target host: macOS 14+ with Xcode 15 CLI tools (not available in container)
+  - Toolchain: Planned use of CMake-produced static libs for simulator/device
+  - Additional toolchains: `xcodebuild`, `lipo`
+- Commands executed:
+  - _Not executed in this environment; documented workflow only._
+- Artifact produced (path, size): _Pending_
+- Issues observed:
+  - Need repeatable script to merge simulator + device archives; packaging must bundle headers + module map.
+- Mitigations attempted:
+  - Authored shell script outline using `xcodebuild -create-xcframework` once static libs exist.
+- Recommendation / impact on decision:
+  - Prefer `.xcframework` as final deliverable for Swift integration; requires follow-up once static libs built on macOS.
+
+### Experiment P-003 – SwiftPM binary target investigation
+- Environment:
+  - Research only; relies on `.xcframework` artifact from P-002
+  - Toolchain: Swift Package Manager (Xcode 15)
+- Commands executed:
+  - _Not executed yet; recorded steps to compute checksum and host artifact._
+- Artifact produced (path, size): _Pending_
+- Issues observed:
+  - Hosting/distribution strategy unresolved; need to align with licensing for AGPL components.
+- Mitigations attempted:
+  - Drafted checklist for Developer Experience agent covering checksum automation and versioning.
+- Recommendation / impact on decision:
+  - Defer SwiftPM packaging until after `.xcframework` pipeline is validated; keep as stretch goal for Phase 1.
 ```
 
 ## 3. Open Questions
-- _(capture decisions or data gaps that need to be resolved before M0 closure)_
+- Clarify whether OpenVDB-dependent functionality must ship in Phase 1 or can be deferred alongside volumetric features.
+- Confirm legal review for distributing AGPL-licensed static libraries inside `.xcframework` bundles.
+- Determine hosting location (self-hosted vs. Git LFS) for binary artifacts referenced by SwiftPM.
 
 > **Reminder:** Attach relevant log files or CI job links where possible so future phases can reproduce the results.

--- a/spec/phase1_decisions.md
+++ b/spec/phase1_decisions.md
@@ -4,7 +4,7 @@
 
 | ID | Date | Decision | Context / Options Considered | Owner(s) | Impacted Milestones | Follow-up Actions | Status |
 |----|------|----------|-------------------------------|----------|---------------------|-------------------|--------|
-| DEC-0001 | _(YYYY-MM-DD)_ | _(Decision summary)_ | _(Problem framing & evaluated options)_ | _(Names)_ | _(e.g., M0, M1)_ | _(Tasks, due dates)_ | _(Open/Closed)_ |
+| DEC-0001 | 2025-09-21 | Target `.xcframework` as distributable for Orca core | Evaluated static `.a` (manual linking), `.xcframework`, and SwiftPM binary target. Static `.a` build blocked on Linux container; `.xcframework` best aligns with Swift integration and future SwiftPM distribution. Details captured in `spec/m0_packaging_findings.md`. | Core Packaging Agent + Bridge & Data Agent | M0, M2, M3 | Provision macOS builder; integrate `ios-cmake` toolchain; draft packaging script for simulator/device archives | Open |
 
 > **Instructions:**
 > - Keep entries concise but link to supporting documents (e.g., `spec/m0_packaging_findings.md`).


### PR DESCRIPTION
## Summary
- Captured M0 dependency inventory status and mitigation notes for the iOS packaging effort.
- Logged packaging experiments, blockers, and open questions leading to the `.xcframework` recommendation.
- Documented the Swift↔︎C++ bridge spike plan and synced the decision log with next steps.

## Testing
- Not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d03636e8cc832b9fb543164be91d6f